### PR TITLE
Upgrade dependency to avoid Axios issue

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -5,9 +5,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "typescript",
       "license": "MIT",
       "dependencies": {
-        "projectmanager-sdk": "^97.0.2178"
+        "projectmanager-sdk": "^98.0.2363"
       },
       "devDependencies": {
         "@types/node": "^20.8.4",
@@ -145,11 +146,13 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -550,13 +553,18 @@
       }
     },
     "node_modules/projectmanager-sdk": {
-      "version": "97.0.2178",
-      "resolved": "https://registry.npmjs.org/projectmanager-sdk/-/projectmanager-sdk-97.0.2178.tgz",
-      "integrity": "sha512-XkfYJgNDIcww1xAlemXCTiXz9FCdegH9tfeWB7/lLfn4Yz7Dvl9jgTIDyYixZyrBskSG6dL6uEN4hGtBkP2mXQ==",
+      "version": "98.0.2363",
+      "resolved": "https://registry.npmjs.org/projectmanager-sdk/-/projectmanager-sdk-98.0.2363.tgz",
+      "integrity": "sha512-pY8Wv/7UUf76btC7WIADHyCvZnHqs1MNlcuDzkmdfWdJwvbg8aoEUAOJKUBiBbTZ/tdNTonjahAo0HtNFSsXhg==",
       "dependencies": {
-        "axios": "^0.24.0",
+        "axios": "^1.6.2",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -15,6 +15,6 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "projectmanager-sdk": "^97.0.2178"
+    "projectmanager-sdk": "^98.0.2363"
   }
 }


### PR DESCRIPTION
Looks like the older version of Axios used in SDK v97 has a reported vulnerability.  Upgrade to SDK v98.