### PR TITLE
Implement account cloning feature in PmTask

### DIFF
--- a/csharp/PmTask/Clone/AccountCloneHelper.cs
+++ b/csharp/PmTask/Clone/AccountCloneHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Cryptography;
+using System.Text;
 using ProjectManager.SDK;
 using ProjectManager.SDK.Models;
 
@@ -94,7 +95,7 @@ public class AccountCloneHelper
             throw new Exception($"Problem fetching customers from source: {srcCustomers.Error.Message}");
         }
 
-        Console.WriteLine($"Cloning {srcCustomers.Data.Length} customers");
+        Console.Write($"Cloning {srcCustomers.Data.Length} customers... ");
 
         // Dest
         var destCustomers = await dest.ProjectCustomer.RetrieveProjectCustomers();
@@ -145,6 +146,7 @@ public class AccountCloneHelper
                     throw new Exception($"Project customer not deleted: {deleteResult.Error.Message}");
                 }
             });
+        Console.WriteLine(results.ToString());
     }
 
     private class SyncResults
@@ -152,6 +154,30 @@ public class AccountCloneHelper
         public int Creates { get; set; }
         public int Updates { get; set; }
         public int Deletes { get; set; }
+
+        public override string ToString()
+        {
+            if (Creates + Updates + Deletes == 0)
+            {
+                return "No changes.";
+            }
+            var sb = new StringBuilder();
+            if (Creates > 0)
+            {
+                sb.Append($"Created {Creates}, ");
+            }
+            if (Updates > 0)
+            {
+                sb.Append($"Updated {Updates}, ");
+            }
+            if (Deletes > 0)
+            {
+                sb.Append($"Deleted {Deletes}, ");
+            }
+
+            sb.Length -= 2;
+            return sb.ToString();
+        }
     }
     
     private static async Task<SyncResults> SyncData<T>(T[] src, T[] dest, AccountMap map, 

--- a/csharp/PmTask/Clone/AccountCloneHelper.cs
+++ b/csharp/PmTask/Clone/AccountCloneHelper.cs
@@ -1,0 +1,86 @@
+﻿using ProjectManager.SDK;
+
+namespace PmTask.Clone;
+
+public class AccountCloneHelper
+{
+    public static async Task CloneAccount(ProjectManagerClient src, ProjectManagerClient dest)
+    {
+        // Customer
+        var customers = await src.ProjectCustomer.RetrieveProjectCustomers();
+        Console.WriteLine($"Cloning {customers.Data.Length} customers");
+        
+        // Manager
+        // what are these?
+        // Project
+        var projects = await src.Project.QueryProjects();
+        Console.WriteLine($"Cloning {projects.Data.Length} projects");
+        
+        // Project Priority
+        var projectPriorities = await src.ProjectPriority.RetrieveProjectPriorities();
+        Console.WriteLine($"Cloning {projectPriorities.Data.Length} projectPriorities");
+        
+        // Project Charge Code
+        var projectChargeCodes = await src.ProjectChargeCode.RetrieveChargeCodes();
+        Console.WriteLine($"Cloning {projectChargeCodes.Data.Length} projectChargeCodes");
+        
+        // Project Folder
+        var projectFolders = await src.ProjectFolder.RetrieveProjectFolders();
+        Console.WriteLine($"Cloning {projectFolders.Data.Length} projectFolders");
+        
+        // Project Members
+        //var projectId = Guid.Empty;
+        //var projectMembers = await src.ProjectMembers.RetrieveProjectMembers(projectId, false);
+        
+        // Project Status
+        var projectStatuses = await src.ProjectStatus.RetrieveProjectStatuses();
+        Console.WriteLine($"Cloning {projectStatuses.Data.Length} projectStatuses");
+
+        // Project Field
+        var projectFields = await src.ProjectField.RetrieveProjectFields();
+        Console.WriteLine($"Cloning {projectFields.Data.Length} projectFields");
+
+        // Project Field Value
+        //var projectFieldValues = await src.ProjectField.RetrieveAllProjectFieldValues(projectId);
+        
+        // Resource
+        var resources = await src.Resource.QueryResources();
+        Console.WriteLine($"Cloning {resources.Data.Length} resources");
+
+        // Skills
+        // Resource Skill
+        var resourceSkills = await src.ResourceSkill.RetrieveResourceSkills();
+        Console.WriteLine($"Cloning {resourceSkills.Data.Length} resourceSkills");
+
+        // Teams
+        // Resource Team
+        var resourceTeams = await src.ResourceTeam.RetrieveResourceTeams();
+        Console.WriteLine($"Cloning {resourceTeams.Data.Length} resourceTeams");
+
+        // Tags
+        var tags = await src.Tag.QueryTags();
+        Console.WriteLine($"Cloning {tags.Data.Length} tags");
+
+        // Tasks
+        var tasks = await src.Task.QueryTasks();
+        Console.WriteLine($"Cloning {tasks.Data.Length} tasks");
+
+        // Task Priority
+        // Task Status
+        //var taskStatus = await src.TaskStatus.RetrieveTaskStatuses(projectId);
+        
+        // Task Tag
+        //var taskTags = await src.TaskTag.ReplaceTaskTags(taskId);
+        // Task ToDo
+        //var taskToDos = await src.TaskTodo.GetTodos(taskId);
+        // Task Field
+        var taskFields = await src.TaskField.QueryTaskFields();
+        Console.WriteLine($"Cloning {taskFields.Data.Length} taskFields");
+
+        // Task Field Value
+        //var taskFieldValues = await src.TaskField.RetrieveAllTaskFieldValues(taskId);
+        // Timesheet
+        var timesheets = await src.Timesheet.QueryTimeSheets();
+        Console.WriteLine($"Cloning {timesheets.Data.Length} timesheets");
+    }
+}

--- a/csharp/PmTask/Clone/AccountCloneHelper.cs
+++ b/csharp/PmTask/Clone/AccountCloneHelper.cs
@@ -134,11 +134,11 @@ public class AccountCloneHelper
             {
                 var teams = r.Teams
                     .Select(t => t.Id!.Value)
-                    .Select(t => map.MapKeyGuid("ResourceTeam", t))
+                    .Select(t => map.MapKeyGuid("ResourceTeam", t)!.Value)
                     .ToArray();
                 var skills = r.Skills
                     .Select(t => t.Id!.Value)
-                    .Select(t => map.MapKeyGuid("ResourceSkill", t))
+                    .Select(t => map.MapKeyGuid("ResourceSkill", t)!.Value)
                     .ToArray();
                 var result = await dest.Resource.CreateResource(new ResourceCreateDto()
                 {

--- a/csharp/PmTask/Clone/AccountMap.cs
+++ b/csharp/PmTask/Clone/AccountMap.cs
@@ -11,4 +11,15 @@ public class AccountMap
     }
 
     public List<AccountMapItem> Items { get; set; } = new();
+
+    public string MapKey(string category, string key)
+    {
+        var match = Items.FirstOrDefault(i => i.Category == category && i.OriginalPrimaryKey == key);
+        if (match != null)
+        {
+            return match.NewPrimaryKey;
+        }
+
+        throw new Exception($"No match found for {category} key {key}");
+    }
 }

--- a/csharp/PmTask/Clone/AccountMap.cs
+++ b/csharp/PmTask/Clone/AccountMap.cs
@@ -22,4 +22,24 @@ public class AccountMap
 
         throw new Exception($"No match found for {category} key {key}");
     }
+    
+    public Guid? MapKeyGuid(string category, Guid? key)
+    {
+        if (key == null)
+        {
+            return null;
+        }
+        
+        var guidString = key.ToString();
+        var match = Items.FirstOrDefault(i => i.Category == category && i.OriginalPrimaryKey == guidString);
+        if (match != null)
+        {
+            if (Guid.TryParse(match.NewPrimaryKey, out var newGuid))
+            {
+                return newGuid;
+            }
+        }
+
+        return null;
+    }
 }

--- a/csharp/PmTask/Clone/AccountMap.cs
+++ b/csharp/PmTask/Clone/AccountMap.cs
@@ -1,0 +1,14 @@
+﻿namespace PmTask.Clone;
+
+public class AccountMap
+{
+    public class AccountMapItem()
+    {
+        public string Category { get; set; }
+        public string Identity { get; set; }
+        public string OriginalPrimaryKey { get; set; }
+        public string NewPrimaryKey { get; set; }
+    }
+
+    public List<AccountMapItem> Items { get; set; } = new();
+}

--- a/csharp/PmTask/Clone/SyncHelper.cs
+++ b/csharp/PmTask/Clone/SyncHelper.cs
@@ -1,0 +1,93 @@
+﻿using System.Text;
+
+namespace PmTask.Clone;
+
+public class SyncHelper
+{
+    public class SyncResults
+    {
+        public int Creates { get; set; }
+        public int Updates { get; set; }
+        public int Deletes { get; set; }
+
+        public override string ToString()
+        {
+            if (Creates + Updates + Deletes == 0)
+            {
+                return "No changes.";
+            }
+            var sb = new StringBuilder();
+            if (Creates > 0)
+            {
+                sb.Append($"Created {Creates}, ");
+            }
+            if (Updates > 0)
+            {
+                sb.Append($"Updated {Updates}, ");
+            }
+            if (Deletes > 0)
+            {
+                sb.Append($"Deleted {Deletes}, ");
+            }
+
+            sb.Length -= 2;
+            return sb.ToString();
+        }
+    }
+    
+    /// <summary>
+    /// Execute a sync action on a specific data type 
+    /// </summary>
+    public static async Task<SyncResults> SyncData<T>(T[] src, T[] dest, AccountMap map, 
+        Func<T, string> identityFunc, 
+        Func<T, string> primaryKeyFunc,
+        Func<T, Task<string>> createFunc, 
+        Func<T, T, bool> compareFunc,
+        Func<T, T, Task> updateFunc, 
+        Func<T, Task> deleteFunc)
+    {
+        var results = new SyncResults();
+        
+        // Convert our destination list to a dictionary for fast lookup
+        var destMap = dest.ToDictionary(d => identityFunc(d));
+        var destKeyMap = dest.ToDictionary(d => primaryKeyFunc(d));
+        var keysToDelete = dest.Select(d => primaryKeyFunc(d)).ToList();
+        foreach (var item in src)
+        { 
+            var identityString = identityFunc(item);
+            var primaryKeyString = primaryKeyFunc(item);
+            if (destMap.TryGetValue(identityString, out var matchingItem))
+            {
+                // Since this key matches and is valid, don't delete it after sync completes
+                keysToDelete.Remove(primaryKeyFunc(matchingItem));
+                if (!compareFunc(item, matchingItem))
+                {
+                    await updateFunc(item, matchingItem);
+                    results.Updates++;
+                }
+            }
+            else
+            {
+                var newPrimaryKey = await createFunc(item);
+                results.Creates++;
+                map.Items.Add(new AccountMap.AccountMapItem()
+                {
+                    Category = nameof(T), 
+                    Identity = identityString, 
+                    OriginalPrimaryKey = primaryKeyString,
+                    NewPrimaryKey = newPrimaryKey,
+                });
+            }
+        }
+        
+        // Delete other items that shouldn't continue to exist
+        foreach (var key in keysToDelete)
+        {
+            var itemToDelete = destKeyMap[key];
+            await deleteFunc(itemToDelete);
+            results.Deletes++;
+        }
+
+        return results;
+    }
+}

--- a/csharp/PmTask/Clone/SyncHelper.cs
+++ b/csharp/PmTask/Clone/SyncHelper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using ProjectManager.SDK.Models;
 
 namespace PmTask.Clone;
 
@@ -119,5 +120,37 @@ public class SyncHelper
         }
 
         return results;
+    }
+
+    public static void MatchData<T>(
+        string category,
+        T[] src, 
+        T[] dest, 
+        AccountMap map, 
+        Func<T, string> identityFunc, 
+        Func<T, string> primaryKeyFunc)
+    {
+        var results = new SyncResults();
+        
+        // Convert our destination list to a dictionary for fast lookup
+        var destMap = dest.ToDictionary(d => identityFunc(d));
+        var keysToDelete = dest.Select(d => primaryKeyFunc(d)).ToList();
+        foreach (var item in src)
+        { 
+            var identityString = identityFunc(item);
+            var primaryKeyString = primaryKeyFunc(item);
+            if (destMap.TryGetValue(identityString, out var matchingItem))
+            {
+                // If the objects are identical, no changes need to be made
+                string newPrimaryKey = primaryKeyFunc(matchingItem);
+                map.Items.Add(new AccountMap.AccountMapItem()
+                {
+                    Category = category,
+                    Identity = identityString,
+                    OriginalPrimaryKey = primaryKeyString,
+                    NewPrimaryKey = newPrimaryKey,
+                });
+            }
+        }
     }
 }

--- a/csharp/PmTask/PmHelper.cs
+++ b/csharp/PmTask/PmHelper.cs
@@ -180,4 +180,22 @@ public static class PmHelper
             }
         }
     }
+
+    public static async Task<AstroResult<T>> ThrowOnError<T>(this Task<AstroResult<T>> task, string? actionName)
+    {
+        var result = await task;
+        if (!result.Success)
+        {
+            if (actionName == null)
+            {
+                throw new Exception($"{actionName}: {result.Error.Message}");
+            }
+            else
+            {
+                throw new Exception($"Failure in AstroResult<{nameof(T)}>: {result.Error.Message}");
+            }
+        }
+
+        return result;
+    }
 }

--- a/csharp/PmTask/PmTask.csproj
+++ b/csharp/PmTask/PmTask.csproj
@@ -12,7 +12,7 @@
       <PackageReference Include="CommandLineParser" Version="2.9.1" />
       <PackageReference Include="CSVFile" Version="3.2.0" />
       <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
-      <PackageReference Include="ProjectManager.SDK" Version="117.0.4438" />
+      <PackageReference Include="ProjectManager.SDK" Version="130.1.162" />
       <PackageReference Include="RestSharp" Version="112.0.0" />
       <PackageReference Include="RunProcessAsTask" Version="1.2.4" />
     </ItemGroup>

--- a/csharp/PmTask/Program.cs
+++ b/csharp/PmTask/Program.cs
@@ -5,6 +5,7 @@ using System.Web;
 using CommandLine;
 using Microsoft.Extensions.FileSystemGlobbing;
 using PmTask;
+using PmTask.Clone;
 using PmTask.SonarClient;
 using PmTask.Sync;
 using ProjectManager.SDK;
@@ -130,6 +131,13 @@ public static class Program
         [Option("message", HelpText = "The text, in markdown format, to add to the discussion")]
         public string? Message { get; set; }
     }
+
+    [Verb("clone-account", HelpText = "Clone one account into another")]
+    private class CloneAccountOptions : BaseOptions
+    {
+        [Option("newkey", Required = true, HelpText = "The API key of the new account that will receive the cloned data")]
+        public string? NewAccountApiKey { get; set; }
+    }
     
     private	static Type[] LoadVerbs()
     {
@@ -150,6 +158,47 @@ public static class Program
         await parsed.WithParsedAsync<SonarCloudOptions>(ImportSonarCloud);
         await parsed.WithParsedAsync<GitBlameFileOptions>(GitBlameFiles);
         await parsed.WithParsedAsync<LogTimeOptions>(LogTime);
+        await parsed.WithParsedAsync<CloneAccountOptions>(CloneAccount);
+    }
+
+    private static async Task CloneAccount(CloneAccountOptions options)
+    {
+        var src = await MakeClient(options);
+        if (src == null)
+        {
+            return;
+        }
+
+        // Check privileges for source account
+        var srcMe = await src.Me.RetrieveMe();
+        if (srcMe.Data.Permissions.EditAllProjects != true)
+        {
+            Console.WriteLine(
+                $"The user {srcMe.Data.EmailAddress} within workspace {srcMe.Data.WorkSpaceName} does not have EditAllProjects permission.");
+            Console.WriteLine("This permission is required to ensure all projects can be cloned properly.");
+            Console.WriteLine("Please try again using an API key that has EditAllProjects permission.");
+            return;
+        }
+        Console.WriteLine($"Copying from account {srcMe.Data.WorkSpaceName} as {srcMe.Data.EmailAddress}.");
+        
+        // Check privileges for destination account
+        var dest = ProjectManagerClient
+            .WithEnvironment("production")
+            .WithMachineName(Environment.MachineName)
+            .WithBearerToken(options.NewAccountApiKey)
+            .WithAppName("PmTask");
+        var destMe = await dest.Me.RetrieveMe();
+        if (destMe.Data.Permissions.EditAllProjects != true)
+        {
+            Console.WriteLine(
+                $"The user {destMe.Data.EmailAddress} within workspace {destMe.Data.WorkSpaceName} does not have EditAllProjects permission.");
+            Console.WriteLine("This permission is required to ensure all projects can be cloned properly.");
+            Console.WriteLine("Please try again using an API key that has EditAllProjects permission.");
+            return;
+        }
+        
+        // This does all the work
+        await AccountCloneHelper.CloneAccount(src, dest);
     }
 
     private static async Task LogTime(LogTimeOptions options)
@@ -582,7 +631,7 @@ public static class Program
         if (environmentString != null)
         {
             client = ProjectManagerClient
-                .WithCustomEnvironment(new Uri(environmentString))
+                .WithCustomEnvironment(new Uri(environmentString), null)
                 .WithMachineName(Environment.MachineName)
                 .WithBearerToken(apiKey)
                 .WithAppName("PmTask");


### PR DESCRIPTION
Let's implement account cloning as thoroughly as possible so that a user could duplicate their account into a new one.

For account cloning:
* We will attempt to sync all data that can be synced.
* We will not duplicate users, only resources.  This means that during syncing, a user with a login on the source system will be created as a synthetic non-login resource in the destination system.